### PR TITLE
Add installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,20 @@ a backend. Use the `/connect` endpoint to configure this server:
 * `GET /connect/` – retrieve the currently configured backend connection.
 
 The connection configuration is saved in `data/config.json`.
+
+## Automated installation
+
+For a system-wide deployment, run the provided `setup.sh` script. It copies the
+repository to `/opt/CDNSAdmin` and installs the Python requirements in a
+virtual environment:
+
+```bash
+sudo ./setup.sh
+```
+
+After installation activate the environment and start the application:
+
+```bash
+source /opt/CDNSAdmin/venv/bin/activate
+python /opt/CDNSAdmin/app.py
+```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install CDNSAdmin to /opt/CDNSAdmin using a Python virtual environment
+TARGET_DIR="/opt/CDNSAdmin"
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+sudo mkdir -p "$TARGET_DIR"
+
+# copy repository files excluding the virtual environment if it already exists
+sudo rsync -a --delete --exclude 'venv' "$REPO_DIR/" "$TARGET_DIR/"
+
+# create virtual environment
+if [ ! -d "$TARGET_DIR/venv" ]; then
+    sudo python3 -m venv "$TARGET_DIR/venv"
+fi
+
+sudo "$TARGET_DIR/venv/bin/pip" install --upgrade pip
+sudo "$TARGET_DIR/venv/bin/pip" install -r "$TARGET_DIR/requirements.txt"
+
+echo "Installation completed. To run CDNSAdmin:"
+echo "source $TARGET_DIR/venv/bin/activate && python $TARGET_DIR/app.py"


### PR DESCRIPTION
## Summary
- add `setup.sh` for automated installation of CDNSAdmin
- document how to run the installer in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bb71d905c83339c236d80df63181f