### PR TITLE
Expose Flask app on LAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ CDNSAdmin is a web-based administration interface for managing a CoreDNS deploym
    python app.py
    ```
 
-After starting, open `http://localhost:5000` in your browser to verify the application is running.
+After starting, open `http://<server-ip>:5000` in your browser to verify the application is running.
+The server listens on `0.0.0.0` by default so it is reachable from your LAN.
 
 ## Zone management API
 

--- a/app.py
+++ b/app.py
@@ -3,4 +3,5 @@ from cdnsadmin import create_app
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Listen on all network interfaces so the WebUI is reachable on the LAN
+    app.run(debug=True, host="0.0.0.0")


### PR DESCRIPTION
## Summary
- run the Flask app on `0.0.0.0` so the web interface is reachable on the network
- document the new address in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bd961590c8333a7284751bf1e201e