### PR TITLE
Fix missing templates

### DIFF
--- a/cdnsadmin/__init__.py
+++ b/cdnsadmin/__init__.py
@@ -1,9 +1,11 @@
 from flask import Flask
+import os
 
 
 def create_app():
     """Create and configure the Flask application."""
-    app = Flask(__name__)
+    template_dir = os.path.join(os.path.dirname(__file__), '..', 'templates')
+    app = Flask(__name__, template_folder=template_dir)
     app.config['SECRET_KEY'] = 'change-me'
     
     # Register blueprints for modular functionality


### PR DESCRIPTION
## Summary
- fix template path for Flask app so index.html loads

## Testing
- `python -m py_compile cdnsadmin/*.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685be0bb96588333af0654c43a6b60d2